### PR TITLE
Verify specialized journal data saving

### DIFF
--- a/src/app/journals/cbt-therapy/page.tsx
+++ b/src/app/journals/cbt-therapy/page.tsx
@@ -18,6 +18,13 @@ const EMOTIONS = [
   { label: 'Excited', value: 'excited', color: 'bg-pink-500' },
 ];
 
+function formatDateKey(d: Date) {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export default function CBTTherapyJournal() {
   const { user } = useAuth();
   const router = useRouter();
@@ -59,7 +66,8 @@ export default function CBTTherapyJournal() {
         journalType: 'cbt-therapy',
         userId: user.uid,
         timestamp: serverTimestamp(),
-        dateKey: new Date().toISOString().split('T')[0],
+        createdAt: serverTimestamp(),
+        dateKey: formatDateKey(new Date()),
         
         // Core CBT data
         situation: situation.trim(),

--- a/src/app/journals/daily-checkin/page.tsx
+++ b/src/app/journals/daily-checkin/page.tsx
@@ -26,6 +26,13 @@ const SELF_CARE_ACTIVITIES = [
   'Nature Time'
 ];
 
+function formatDateKey(d: Date) {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export default function DailyCheckInJournal() {
   const { user } = useAuth();
   const router = useRouter();
@@ -86,7 +93,8 @@ export default function DailyCheckInJournal() {
         journalType: 'daily-checkin',
         userId: user.uid,
         timestamp: serverTimestamp(),
-        dateKey: new Date().toISOString().split('T')[0],
+        createdAt: serverTimestamp(),
+        dateKey: formatDateKey(new Date()),
         
         // Core data
         mood: {

--- a/src/app/journals/goal-achievement/page.tsx
+++ b/src/app/journals/goal-achievement/page.tsx
@@ -21,6 +21,13 @@ interface DailyTask {
   completed: boolean;
 }
 
+function formatDateKey(d: Date) {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export default function GoalAchievementJournal() {
   const { user } = useAuth();
   const router = useRouter();
@@ -146,7 +153,8 @@ export default function GoalAchievementJournal() {
         journalType: 'goal-achievement',
         userId: user.uid,
         timestamp: serverTimestamp(),
-        dateKey: new Date().toISOString().split('T')[0],
+        createdAt: serverTimestamp(),
+        dateKey: formatDateKey(new Date()),
         
         // Goal reference
         goalId: currentGoal.id,

--- a/src/app/journals/gratitude/page.tsx
+++ b/src/app/journals/gratitude/page.tsx
@@ -20,6 +20,13 @@ const GRATITUDE_AFFIRMATIONS = [
   "I am blessed beyond measure in countless ways"
 ];
 
+function formatDateKey(d: Date) {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export default function GratitudeJournal() {
   const { user } = useAuth();
   const router = useRouter();
@@ -74,7 +81,8 @@ export default function GratitudeJournal() {
         journalType: 'gratitude',
         userId: user.uid,
         timestamp: serverTimestamp(),
-        dateKey: new Date().toISOString().split('T')[0],
+        createdAt: serverTimestamp(),
+        dateKey: formatDateKey(new Date()),
         
         // Core gratitude data
         dailyHighlight: dailyHighlight.trim() || null,

--- a/src/app/journals/relationship/page.tsx
+++ b/src/app/journals/relationship/page.tsx
@@ -28,6 +28,13 @@ const COMMUNICATION_STYLES = [
   { label: 'Conflict', value: 'conflict', color: 'bg-red-500' }
 ];
 
+function formatDateKey(d: Date) {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export default function RelationshipJournal() {
   const { user } = useAuth();
   const router = useRouter();
@@ -74,7 +81,8 @@ export default function RelationshipJournal() {
         journalType: 'relationship',
         userId: user.uid,
         timestamp: serverTimestamp(),
-        dateKey: new Date().toISOString().split('T')[0],
+        createdAt: serverTimestamp(),
+        dateKey: formatDateKey(new Date()),
         
         // Core relationship data
         relationship: {


### PR DESCRIPTION
Add `createdAt` timestamp and standardize `dateKey` formatting for specialized journals to ensure consistent data persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7069100-eab8-4f6f-acb5-849b2a1ddcce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7069100-eab8-4f6f-acb5-849b2a1ddcce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

