### PR TITLE
Fix self-messaging in chat

### DIFF
--- a/src/components/messaging/DirectMessageInterface.tsx
+++ b/src/components/messaging/DirectMessageInterface.tsx
@@ -128,6 +128,14 @@ export default function DirectMessageInterface({
       return;
     }
     
+    // Prevent users from messaging themselves
+    if (user.uid === otherUserId) {
+      console.error('❌ Cannot message yourself');
+      setError('You cannot message yourself');
+      setLoading(false);
+      return;
+    }
+    
     console.log('🔄 Initializing direct message chat...', { 
       currentUserId: user.uid, 
       otherUserId 

--- a/src/components/messaging/MessagingHub.tsx
+++ b/src/components/messaging/MessagingHub.tsx
@@ -73,7 +73,7 @@ export default function MessagingHub({
           limitCount: 10,
         });
         
-        // Filter out already selected participants
+        // Filter out already selected participants and current user
         const filteredResults = results.filter(profile => 
           !selectedParticipants.includes(profile.userId) && 
           profile.userId !== user.uid
@@ -127,6 +127,12 @@ export default function MessagingHub({
   };
 
   const handleStartDirectMessage = (userId: string) => {
+    // Prevent users from messaging themselves
+    if (userId === user?.uid) {
+      console.error('Cannot message yourself');
+      return;
+    }
+    
     setSelectedOtherUserId(userId);
     setViewMode('direct');
   };

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -150,6 +150,11 @@ export async function createSimpleChat(
 ): Promise<string> {
   console.log('🧪 Creating SIMPLE chat for testing...', { currentUserId, otherUserId });
   
+  // Prevent users from messaging themselves
+  if (currentUserId === otherUserId) {
+    throw new Error('You cannot message yourself');
+  }
+  
   try {
     // Create a consistent chat ID that both users will see
     // Sort user IDs to ensure same chat ID regardless of who initiates
@@ -202,6 +207,11 @@ export async function createDirectChat(
   otherUserId: string
 ): Promise<string> {
   console.log('🔄 Creating direct chat...', { currentUserId, otherUserId });
+  
+  // Prevent users from messaging themselves
+  if (currentUserId === otherUserId) {
+    throw new Error('You cannot message yourself');
+  }
   
   // Create a consistent chat ID that both users will see
   // Sort user IDs to ensure same chat ID regardless of who initiates


### PR DESCRIPTION
Add validation to prevent users from messaging themselves in direct and simple chat creation, and client-side interfaces.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cc7ac44-27c5-4970-854d-60b0965403f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cc7ac44-27c5-4970-854d-60b0965403f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

