### PR TITLE
Fix fam tab user name display

### DIFF
--- a/src/components/social/AuraFamilyList.tsx
+++ b/src/components/social/AuraFamilyList.tsx
@@ -254,6 +254,9 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
                     <h3 className="font-semibold text-gray-900 dark:text-white">
                       {member.name}
                     </h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      @{member.username || member.name || 'user'}
+                    </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">
                         {member.auraPoints.toLocaleString()} aura points

--- a/src/components/social/AuraFamilyList.tsx
+++ b/src/components/social/AuraFamilyList.tsx
@@ -42,18 +42,25 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
         const friends = await getFriends(user.uid);
         
         // Convert friends to AuraFamilyMember format
-        members = friends.map(friend => ({
-          userId: friend.friendId,
-          name: friend.friendProfile?.name || 'Unknown',
-          username: friend.friendProfile?.username || `user${friend.friendId.slice(-4)}`,
-          avatar: friend.friendProfile?.avatar,
-          joinedAt: friend.friendSince,
-          auraPoints: 0, // Default aura points since it's not in PublicProfile
-          lastActivity: friend.friendProfile?.lastSeen,
-          isOnline: friend.friendProfile?.isOnline || false,
-          mutualConnections: friend.mutualFriends || 0,
-          sharedInterests: friend.sharedInterests || friend.friendProfile?.interests || [],
-        }));
+        members = friends.map(friend => {
+          // Ensure username is never empty or undefined
+          const username = friend.friendProfile?.username && friend.friendProfile.username.trim() 
+            ? friend.friendProfile.username 
+            : `user${friend.friendId.slice(-4)}`;
+          
+          return {
+            userId: friend.friendId,
+            name: friend.friendProfile?.name || 'Unknown',
+            username: username,
+            avatar: friend.friendProfile?.avatar,
+            joinedAt: friend.friendSince,
+            auraPoints: 0, // Default aura points since it's not in PublicProfile
+            lastActivity: friend.friendProfile?.lastSeen,
+            isOnline: friend.friendProfile?.isOnline || false,
+            mutualConnections: friend.mutualFriends || 0,
+            sharedInterests: friend.sharedInterests || friend.friendProfile?.interests || [],
+          };
+        });
       }
       
       const familyStats = await getAuraFamilyStats(user.uid);
@@ -250,7 +257,7 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
                       {member.name}
                     </h3>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username}
+                      @{member.username || `user${member.userId.slice(-4)}`}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/AuraFamilyList.tsx
+++ b/src/components/social/AuraFamilyList.tsx
@@ -12,7 +12,7 @@ import {
   AuraFamilyMember,
   AuraFamilyStats
 } from '@/lib/auraFamilySystem';
-import { getFriends } from '@/lib/socialSystem';
+import { getFriends, ensureUsernameSet } from '@/lib/socialSystem';
 
 interface AuraFamilyListProps {
   onMemberRemoved?: () => void;
@@ -42,11 +42,9 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
         const friends = await getFriends(user.uid);
         
         // Convert friends to AuraFamilyMember format
-        members = friends.map(friend => {
-          // Ensure username is never empty or undefined
-          const username = friend.friendProfile?.username && friend.friendProfile.username.trim() 
-            ? friend.friendProfile.username 
-            : `user${friend.friendId.slice(-4)}`;
+        members = await Promise.all(friends.map(async friend => {
+          // Get proper username using ensureUsernameSet
+          const username = await ensureUsernameSet(friend.friendId);
           
           return {
             userId: friend.friendId,
@@ -60,7 +58,7 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
             mutualConnections: friend.mutualFriends || 0,
             sharedInterests: friend.sharedInterests || friend.friendProfile?.interests || [],
           };
-        });
+        }));
       }
       
       const familyStats = await getAuraFamilyStats(user.uid);

--- a/src/components/social/AuraFamilyList.tsx
+++ b/src/components/social/AuraFamilyList.tsx
@@ -254,9 +254,6 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
                     <h3 className="font-semibold text-gray-900 dark:text-white">
                       {member.name}
                     </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username}
-                    </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">
                         {member.auraPoints.toLocaleString()} aura points

--- a/src/components/social/AuraFamilyList.tsx
+++ b/src/components/social/AuraFamilyList.tsx
@@ -255,7 +255,7 @@ export default function AuraFamilyList({ onMemberRemoved }: AuraFamilyListProps)
                       {member.name}
                     </h3>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username || `user${member.userId.slice(-4)}`}
+                      @{member.username}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/FamList.tsx
+++ b/src/components/social/FamList.tsx
@@ -257,6 +257,9 @@ export default function FamList({ onMemberRemoved }: FamListProps) {
                     <h3 className="font-semibold text-gray-900 dark:text-white">
                       {member.name}
                     </h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      @{member.username || member.name || 'user'}
+                    </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">
                         {member.auraPoints.toLocaleString()} aura points

--- a/src/components/social/FamList.tsx
+++ b/src/components/social/FamList.tsx
@@ -257,9 +257,6 @@ export default function FamList({ onMemberRemoved }: FamListProps) {
                     <h3 className="font-semibold text-gray-900 dark:text-white">
                       {member.name}
                     </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username}
-                    </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">
                         {member.auraPoints.toLocaleString()} aura points

--- a/src/components/social/FamList.tsx
+++ b/src/components/social/FamList.tsx
@@ -258,7 +258,7 @@ export default function FamList({ onMemberRemoved }: FamListProps) {
                       {member.name}
                     </h3>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username}
+                      @{member.username || `user${member.userId.slice(-4)}`}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/FamList.tsx
+++ b/src/components/social/FamList.tsx
@@ -258,7 +258,7 @@ export default function FamList({ onMemberRemoved }: FamListProps) {
                       {member.name}
                     </h3>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username || `user${member.userId.slice(-4)}`}
+                      @{member.username}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/FamSearch.tsx
+++ b/src/components/social/FamSearch.tsx
@@ -247,7 +247,7 @@ export default function FamSearch({ onRequestSent }: FamSearchProps) {
                           })()}
                         </div>
                         <p className="text-sm text-gray-500 dark:text-gray-400">
-                          {profile.name}
+                          @{profile.username || profile.name || 'user'}
                         </p>
                         {profile.bio && (
                           <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">

--- a/src/components/social/FamSearch.tsx
+++ b/src/components/social/FamSearch.tsx
@@ -247,7 +247,7 @@ export default function FamSearch({ onRequestSent }: FamSearchProps) {
                           })()}
                         </div>
                         <p className="text-sm text-gray-500 dark:text-gray-400">
-                          @{profile.username}
+                          {profile.name}
                         </p>
                         {profile.bio && (
                           <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">

--- a/src/components/social/FamSuggestions.tsx
+++ b/src/components/social/FamSuggestions.tsx
@@ -151,6 +151,9 @@ export default function FamSuggestions({ onRequestSent }: FamSuggestionsProps) {
                       <h3 className="font-semibold text-gray-900 dark:text-white text-lg">
                         {suggestion.name}
                       </h3>
+                      <span className="text-sm text-gray-500 dark:text-gray-400">
+                        @{suggestion.username || suggestion.name || 'user'}
+                      </span>
                     </div>
                     
                     {suggestion.bio && (

--- a/src/components/social/FamSuggestions.tsx
+++ b/src/components/social/FamSuggestions.tsx
@@ -151,11 +151,6 @@ export default function FamSuggestions({ onRequestSent }: FamSuggestionsProps) {
                       <h3 className="font-semibold text-gray-900 dark:text-white text-lg">
                         {suggestion.name}
                       </h3>
-                      {suggestion.username && (
-                        <span className="text-sm text-gray-500 dark:text-gray-400">
-                          @{suggestion.username}
-                        </span>
-                      )}
                     </div>
                     
                     {suggestion.bio && (

--- a/src/components/social/UniversalAuraFamList.tsx
+++ b/src/components/social/UniversalAuraFamList.tsx
@@ -242,7 +242,7 @@ export default function UniversalAuraFamList({ onMemberRemoved }: UniversalAuraF
                       </span>
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username}
+                      {member.name}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/UniversalAuraFamList.tsx
+++ b/src/components/social/UniversalAuraFamList.tsx
@@ -242,7 +242,7 @@ export default function UniversalAuraFamList({ onMemberRemoved }: UniversalAuraF
                       </span>
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {member.name}
+                      @{member.username || member.name || 'user'}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/UniversalAuraFamList.tsx
+++ b/src/components/social/UniversalAuraFamList.tsx
@@ -242,7 +242,7 @@ export default function UniversalAuraFamList({ onMemberRemoved }: UniversalAuraF
                       </span>
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username}
+                      @{member.username || `user${member.userId.slice(-4)}`}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/components/social/UniversalAuraFamList.tsx
+++ b/src/components/social/UniversalAuraFamList.tsx
@@ -242,7 +242,7 @@ export default function UniversalAuraFamList({ onMemberRemoved }: UniversalAuraF
                       </span>
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      @{member.username || `user${member.userId.slice(-4)}`}
+                      @{member.username}
                     </p>
                     <div className="flex items-center gap-4 mt-1">
                       <span className="text-sm text-purple-600 dark:text-purple-400">

--- a/src/lib/auraFamilySystem.ts
+++ b/src/lib/auraFamilySystem.ts
@@ -61,10 +61,15 @@ export async function getAuraFamilyMembers(currentUserId: string): Promise<AuraF
         const friendshipDoc = await getDoc(doc(db, 'friendships', `${currentUserId}_${friendId}`));
         const friendshipData = friendshipDoc.exists() ? friendshipDoc.data() : {};
 
+        // Ensure username is never empty or undefined
+        const username = (friendProfile?.username && friendProfile.username.trim()) || 
+                        (friendData.username && friendData.username.trim()) || 
+                        `user${friendId.slice(-4)}`;
+
         familyMembers.push({
           userId: friendId,
           name: friendProfile?.name || friendData.name || 'Unknown',
-          username: friendProfile?.username || friendData.username || 'unknown',
+          username: username,
           avatar: friendProfile?.avatar || friendData.avatar,
           joinedAt: friendData.createdAt || friendshipData.createdAt,
           auraPoints: friendProfile?.auraPoints || friendData.auraPoints || 0,

--- a/src/lib/auraFamilySystem.ts
+++ b/src/lib/auraFamilySystem.ts
@@ -16,7 +16,7 @@ import {
   Unsubscribe,
 } from 'firebase/firestore';
 import { db } from './firebase';
-import { PublicProfile } from './socialSystem';
+import { PublicProfile, ensureUsernameSet } from './socialSystem';
 
 export type AuraFamilyMember = {
   userId: string;
@@ -61,10 +61,8 @@ export async function getAuraFamilyMembers(currentUserId: string): Promise<AuraF
         const friendshipDoc = await getDoc(doc(db, 'friendships', `${currentUserId}_${friendId}`));
         const friendshipData = friendshipDoc.exists() ? friendshipDoc.data() : {};
 
-        // Ensure username is never empty or undefined
-        const username = (friendProfile?.username && friendProfile.username.trim()) || 
-                        (friendData.username && friendData.username.trim()) || 
-                        `user${friendId.slice(-4)}`;
+        // Get proper username using ensureUsernameSet
+        const username = await ensureUsernameSet(friendId);
 
         familyMembers.push({
           userId: friendId,

--- a/src/lib/famTrackingSystem.ts
+++ b/src/lib/famTrackingSystem.ts
@@ -20,7 +20,7 @@ import {
   deleteDoc,
 } from 'firebase/firestore';
 import { db } from './firebase';
-import { getPublicProfile } from './socialSystem';
+import { getPublicProfile, ensureUsernameSet } from './socialSystem';
 
 export type FamMember = {
   id: string;
@@ -78,8 +78,8 @@ export async function getFamMembers(userId: string): Promise<FamMember[]> {
       
       for (const famDoc of famSnapshot.docs) {
         const famData = famDoc.data() as FamMember;
-        // Ensure username is never empty or undefined
-        const username = (famData.username && famData.username.trim()) || `user${famData.userId.slice(-4)}`;
+        // Get proper username using ensureUsernameSet
+        const username = await ensureUsernameSet(famData.userId);
         
         // Ensure required fields have default values
         famMembers.push({
@@ -112,8 +112,8 @@ export async function getFamMembers(userId: string): Promise<FamMember[]> {
       
       for (const famDoc of fallbackSnapshot.docs) {
         const famData = famDoc.data() as FamMember;
-        // Ensure username is never empty or undefined
-        const username = (famData.username && famData.username.trim()) || `user${famData.userId.slice(-4)}`;
+        // Get proper username using ensureUsernameSet
+        const username = await ensureUsernameSet(famData.userId);
         
         // Ensure required fields have default values
         famMembers.push({

--- a/src/lib/famTrackingSystem.ts
+++ b/src/lib/famTrackingSystem.ts
@@ -78,12 +78,15 @@ export async function getFamMembers(userId: string): Promise<FamMember[]> {
       
       for (const famDoc of famSnapshot.docs) {
         const famData = famDoc.data() as FamMember;
+        // Ensure username is never empty or undefined
+        const username = (famData.username && famData.username.trim()) || `user${famData.userId.slice(-4)}`;
+        
         // Ensure required fields have default values
         famMembers.push({
           ...famData,
           id: famDoc.id,
           name: famData.name || 'Unknown',
-          username: famData.username || 'unknown',
+          username: username,
           auraPoints: famData.auraPoints || 0,
           isOnline: famData.isOnline || false,
           mutualConnections: famData.mutualConnections || 0,
@@ -109,12 +112,15 @@ export async function getFamMembers(userId: string): Promise<FamMember[]> {
       
       for (const famDoc of fallbackSnapshot.docs) {
         const famData = famDoc.data() as FamMember;
+        // Ensure username is never empty or undefined
+        const username = (famData.username && famData.username.trim()) || `user${famData.userId.slice(-4)}`;
+        
         // Ensure required fields have default values
         famMembers.push({
           ...famData,
           id: famDoc.id,
           name: famData.name || 'Unknown',
-          username: famData.username || 'unknown',
+          username: username,
           auraPoints: famData.auraPoints || 0,
           isOnline: famData.isOnline || false,
           mutualConnections: famData.mutualConnections || 0,

--- a/src/lib/socialSystem.ts
+++ b/src/lib/socialSystem.ts
@@ -277,9 +277,12 @@ export async function getPublicProfile(userId: string): Promise<PublicProfile | 
 // Utility function to ensure username is set for a user
 export async function ensureUsernameSet(userId: string): Promise<string> {
   try {
+    console.log(`🔍 ensureUsernameSet called for ${userId}`);
+    
     // First check public profile
     const publicProfile = await getPublicProfile(userId);
     if (publicProfile?.username) {
+      console.log(`✅ Found username in public profile: ${publicProfile.username}`);
       return publicProfile.username;
     }
     
@@ -288,12 +291,14 @@ export async function ensureUsernameSet(userId: string): Promise<string> {
     if (userDoc.exists()) {
       const userData = userDoc.data();
       const username = userData.username || userData.name || `user${userId.slice(-4)}`;
+      console.log(`📝 Found username in main user document: ${username}`);
       
       // Update public profile with the username
       if (publicProfile) {
         await updateDoc(doc(getPublicProfilesRef(), userId), {
           username: username
         });
+        console.log(`📝 Updated existing public profile with username: ${username}`);
       } else {
         // Create public profile if it doesn't exist
         const publicProfileData: Partial<PublicProfile> = {
@@ -312,6 +317,7 @@ export async function ensureUsernameSet(userId: string): Promise<string> {
           joinedAt: userData.createdAt || serverTimestamp(),
         };
         await setDoc(doc(getPublicProfilesRef(), userId), publicProfileData);
+        console.log(`📝 Created new public profile with username: ${username}`);
       }
       
       return username;

--- a/src/lib/universalAuraFamSystem.ts
+++ b/src/lib/universalAuraFamSystem.ts
@@ -17,7 +17,7 @@ import {
   Unsubscribe,
 } from 'firebase/firestore';
 import { db } from './firebase';
-import { getFriends } from './socialSystem';
+import { getFriends, ensureUsernameSet } from './socialSystem';
 import { PublicProfile } from './socialSystem';
 
 export type UniversalAuraFamMember = {
@@ -56,11 +56,9 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
     console.log('📊 Legacy friends found:', legacyFriends.length);
     
     // Convert legacy friends to universal format
-    const legacyMembers: UniversalAuraFamMember[] = legacyFriends.map(friend => {
-      // Ensure username is never empty or undefined
-      const username = friend.friendProfile?.username && friend.friendProfile.username.trim() 
-        ? friend.friendProfile.username 
-        : `user${friend.friendId.slice(-4)}`;
+    const legacyMembers: UniversalAuraFamMember[] = await Promise.all(legacyFriends.map(async friend => {
+      // Get proper username using ensureUsernameSet
+      const username = await ensureUsernameSet(friend.friendId);
       
       return {
         userId: friend.friendId,
@@ -76,7 +74,7 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
         source: 'legacy',
         friendshipId: friend.id,
       };
-    });
+    }));
 
     // Get friends from the new system (subcollection)
     let newMembers: UniversalAuraFamMember[] = [];
@@ -97,10 +95,8 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
           const friendshipDoc = await getDoc(doc(db, 'friendships', `${currentUserId}_${friendId}`));
           const friendshipData = friendshipDoc.exists() ? friendshipDoc.data() : {};
 
-          // Ensure username is never empty or undefined
-          const username = (friendProfile?.username && friendProfile.username.trim()) || 
-                          (friendData.username && friendData.username.trim()) || 
-                          `user${friendId.slice(-4)}`;
+          // Get proper username using ensureUsernameSet
+          const username = await ensureUsernameSet(friendId);
 
           newMembers.push({
             userId: friendId,

--- a/src/lib/universalAuraFamSystem.ts
+++ b/src/lib/universalAuraFamSystem.ts
@@ -56,20 +56,27 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
     console.log('📊 Legacy friends found:', legacyFriends.length);
     
     // Convert legacy friends to universal format
-    const legacyMembers: UniversalAuraFamMember[] = legacyFriends.map(friend => ({
-      userId: friend.friendId,
-      name: friend.friendProfile?.name || friend.friendProfile?.username || 'Unknown',
-      username: friend.friendProfile?.username || `user${friend.friendId.slice(-4)}`,
-      avatar: friend.friendProfile?.avatar,
-      joinedAt: friend.friendSince,
-      auraPoints: 0, // Default since not in PublicProfile
-      lastActivity: friend.friendProfile?.lastSeen,
-      isOnline: friend.friendProfile?.isOnline || false,
-      mutualConnections: friend.mutualFriends || 0,
-      sharedInterests: friend.sharedInterests || friend.friendProfile?.interests || [],
-      source: 'legacy',
-      friendshipId: friend.id,
-    }));
+    const legacyMembers: UniversalAuraFamMember[] = legacyFriends.map(friend => {
+      // Ensure username is never empty or undefined
+      const username = friend.friendProfile?.username && friend.friendProfile.username.trim() 
+        ? friend.friendProfile.username 
+        : `user${friend.friendId.slice(-4)}`;
+      
+      return {
+        userId: friend.friendId,
+        name: friend.friendProfile?.name || friend.friendProfile?.username || 'Unknown',
+        username: username,
+        avatar: friend.friendProfile?.avatar,
+        joinedAt: friend.friendSince,
+        auraPoints: 0, // Default since not in PublicProfile
+        lastActivity: friend.friendProfile?.lastSeen,
+        isOnline: friend.friendProfile?.isOnline || false,
+        mutualConnections: friend.mutualFriends || 0,
+        sharedInterests: friend.sharedInterests || friend.friendProfile?.interests || [],
+        source: 'legacy',
+        friendshipId: friend.id,
+      };
+    });
 
     // Get friends from the new system (subcollection)
     let newMembers: UniversalAuraFamMember[] = [];
@@ -90,10 +97,15 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
           const friendshipDoc = await getDoc(doc(db, 'friendships', `${currentUserId}_${friendId}`));
           const friendshipData = friendshipDoc.exists() ? friendshipDoc.data() : {};
 
+          // Ensure username is never empty or undefined
+          const username = (friendProfile?.username && friendProfile.username.trim()) || 
+                          (friendData.username && friendData.username.trim()) || 
+                          `user${friendId.slice(-4)}`;
+
           newMembers.push({
             userId: friendId,
             name: friendProfile?.name || friendData.name || friendProfile?.username || friendData.username || 'Unknown',
-            username: friendProfile?.username || friendData.username || `user${friendId.slice(-4)}`,
+            username: username,
             avatar: friendProfile?.avatar || friendData.avatar,
             joinedAt: friendData.createdAt || friendshipData.createdAt,
             auraPoints: friendProfile?.auraPoints || friendData.auraPoints || 0,

--- a/src/lib/universalAuraFamSystem.ts
+++ b/src/lib/universalAuraFamSystem.ts
@@ -59,6 +59,7 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
     const legacyMembers: UniversalAuraFamMember[] = await Promise.all(legacyFriends.map(async friend => {
       // Get proper username using ensureUsernameSet
       const username = await ensureUsernameSet(friend.friendId);
+      console.log(`👤 Legacy friend ${friend.friendId}: username = ${username}`);
       
       return {
         userId: friend.friendId,
@@ -97,6 +98,7 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
 
           // Get proper username using ensureUsernameSet
           const username = await ensureUsernameSet(friendId);
+          console.log(`👤 New friend ${friendId}: username = ${username}`);
 
           newMembers.push({
             userId: friendId,

--- a/src/lib/universalAuraFamSystem.ts
+++ b/src/lib/universalAuraFamSystem.ts
@@ -60,6 +60,7 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
       // Get proper username using ensureUsernameSet
       const username = await ensureUsernameSet(friend.friendId);
       console.log(`👤 Legacy friend ${friend.friendId}: username = ${username}`);
+      console.log(`👤 Legacy friend ${friend.friendId}: friendProfile =`, friend.friendProfile);
       
       return {
         userId: friend.friendId,
@@ -99,6 +100,8 @@ export async function getUniversalAuraFamMembers(currentUserId: string): Promise
           // Get proper username using ensureUsernameSet
           const username = await ensureUsernameSet(friendId);
           console.log(`👤 New friend ${friendId}: username = ${username}`);
+          console.log(`👤 New friend ${friendId}: friendProfile =`, friendProfile);
+          console.log(`👤 New friend ${friendId}: friendData =`, friendData);
 
           newMembers.push({
             userId: friendId,


### PR DESCRIPTION
Fix username display in Aura Fam and Fam tabs to show `userXXXX` fallback instead of just `@` when the username is empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5c0819f-a74c-4dca-a328-66d675ba1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5c0819f-a74c-4dca-a328-66d675ba1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

